### PR TITLE
fix(api): update post req json response

### DIFF
--- a/kafka_connect_api/kafka_connect_api.py
+++ b/kafka_connect_api/kafka_connect_api.py
@@ -384,7 +384,10 @@ class Api:
 
     def post(self, query_path, **kwargs):
         req = self.post_raw(query_path, **kwargs)
-        return req.json()
+        try:
+            return req.json()
+        except ValueError:
+            return req
 
     @evaluate_api_return
     def put_raw(self, query_path, **kwargs) -> Response:


### PR DESCRIPTION
For the Kafka connect REST API there are a number of post requests that don't return JSON e.g. /connectors/restart. In this instance the current code is failing on returning req.json()